### PR TITLE
No dupe pk

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.idea/
+*.iml
+*.log
+.DS_Store
+*.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,35 @@
-# Compiled class file
-*.class
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
 
-# Log file
-*.log
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
 
-# BlueJ files
-*.ctxt
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
 
-# Mobile Tools for Java (J2ME)
-.mtj.tmp/
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
 
-# Package Files #
-*.jar
-*.war
-*.nar
-*.ear
-*.zip
-*.tar.gz
-*.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
-hs_err_pid*
-replay_pid*
+### VS Code ###
+.vscode/
+/.idea/
+/.mvn/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Use an official JDK base image
+FROM openjdk:17-jdk-slim
+
+# Set workdir
+WORKDIR /app
+
+# Copy Maven build artifacts
+COPY ./target/app.jar app.jar
+
+# Expose the app port
+EXPOSE 8080
+
+# Run the app
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:15
+    container_name: ddg-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ddg_init
+    ports:
+      - "5432:5432"
+
+  app:
+    build: .
+    container_name: ddg-app
+    depends_on:
+      - db
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/ddg_init
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+    ports:
+      - "8080:8080"

--- a/src/main/java/com/hisham/dummydatagenerator/DummyDataGeneratorApplication.java
+++ b/src/main/java/com/hisham/dummydatagenerator/DummyDataGeneratorApplication.java
@@ -1,15 +1,25 @@
 package com.hisham.dummydatagenerator;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+import java.time.LocalDateTime;
 
 @EnableJpaRepositories(basePackages = {"com.hisham.dummydatagenerator"})
 
 @SpringBootApplication
 public class DummyDataGeneratorApplication {
 
+	@PostConstruct
+	public static void printStartupVersion() {
+		System.out.println("=== DummyDataGenerator v0.1 Booted at " + LocalDateTime.now() + " ===");
+	}
+
+
 	public static void main(String[] args) {
+		printStartupVersion();
 		SpringApplication.run(DummyDataGeneratorApplication.class, args);
 	}
 

--- a/src/main/java/com/hisham/dummydatagenerator/controller/DummyDataController.java
+++ b/src/main/java/com/hisham/dummydatagenerator/controller/DummyDataController.java
@@ -1,2 +1,33 @@
-package com.hisham.dummydatagenerator.controller;public class DummyDataController {
+package com.hisham.dummydatagenerator.controller;
+
+import com.hisham.dummydatagenerator.generator.DummyDataService;
+import com.hisham.dummydatagenerator.schema.DatabaseIntrospector;
+import com.hisham.dummydatagenerator.schema.TableMetadata;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/data")
+public class DummyDataController {
+
+    @Autowired
+    private DummyDataService dummyDataService;
+
+    @Autowired
+    private DatabaseIntrospector introspector;
+
+    @PostMapping("/{schema}/{table}")
+    public String generateData(@PathVariable String schema,
+                               @PathVariable String table,
+                               @RequestParam(defaultValue = "100") int rows) {
+
+        TableMetadata metadata = introspector.getTableMetadata(schema, table);
+        List<Map<String, Object>> dummyRows = dummyDataService.generateRows(metadata, rows);
+        dummyDataService.insertRows(schema, table, dummyRows);
+
+        return "Inserted " + rows + " dummy rows into " + schema + "." + table;
+    }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/controller/DummyDataController.java
+++ b/src/main/java/com/hisham/dummydatagenerator/controller/DummyDataController.java
@@ -25,7 +25,7 @@ public class DummyDataController {
                                @RequestParam(defaultValue = "100") int rows) {
 
         TableMetadata metadata = introspector.getTableMetadata(schema, table);
-        List<Map<String, Object>> dummyRows = dummyDataService.generateRows(metadata, rows);
+        List<Map<String, Object>> dummyRows = dummyDataService.generateRows(metadata, rows, schema);
         dummyDataService.insertRows(schema, table, dummyRows);
 
         return "Inserted " + rows + " dummy rows into " + schema + "." + table;

--- a/src/main/java/com/hisham/dummydatagenerator/generator/ColumnDataGenerator.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/ColumnDataGenerator.java
@@ -1,2 +1,5 @@
-package com.hisham.dummydatagenerator.generator;public class ColumnDataGenerator {
+package com.hisham.dummydatagenerator.generator;
+
+public interface ColumnDataGenerator {
+    Object generate();
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/DataGeneratorFactory.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/DataGeneratorFactory.java
@@ -1,2 +1,22 @@
-package com.hisham.dummydatagenerator.generator;public class DataGeneratorFactory {
+package com.hisham.dummydatagenerator.generator;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DataGeneratorFactory {
+
+    private static final Map<String, ColumnDataGenerator> generatorMap = new HashMap<>();
+
+    static {
+        generatorMap.put("varchar", new StringGenerator());
+        generatorMap.put("text", new StringGenerator());
+        generatorMap.put("int4", new IntegerGenerator()); // PostgreSQL-specific
+        generatorMap.put("integer", new IntegerGenerator());
+        generatorMap.put("date", new DateGenerator());
+        // add more mappings as needed
+    }
+
+    public static ColumnDataGenerator getGenerator(String sqlType) {
+        return generatorMap.getOrDefault(sqlType.toLowerCase(), () -> null);
+    }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/DateGenerator.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/DateGenerator.java
@@ -1,2 +1,14 @@
-package com.hisham.dummydatagenerator.generator;public class DateGenerator {
+package com.hisham.dummydatagenerator.generator;
+
+import java.time.LocalDate;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class DateGenerator implements ColumnDataGenerator {
+    @Override
+    public Object generate() {
+        long minDay = LocalDate.of(2000, 1, 1).toEpochDay();
+        long maxDay = LocalDate.of(2022, 12, 31).toEpochDay();
+        long randomDay = ThreadLocalRandom.current().nextLong(minDay, maxDay);
+        return LocalDate.ofEpochDay(randomDay);
+    }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/DummyDataService.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/DummyDataService.java
@@ -1,2 +1,74 @@
-package com.hisham.dummydatagenerator.generator;public class DummyDataService {
+package com.hisham.dummydatagenerator.generator;
+
+import com.hisham.dummydatagenerator.schema.TableMetadata;
+import com.hisham.dummydatagenerator.schema.ColumnMetadata;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+public class DummyDataService {
+
+    public List<Map<String, Object>> generateRows(TableMetadata metadata, int rowCount, String schema) {
+        List<Map<String, Object>> rows = new ArrayList<>();
+
+        String pkColumn = metadata.getColumns().stream()
+                .filter(ColumnMetadata::isPrimaryKey)
+                .map(ColumnMetadata::getColumnName)
+                .findFirst().orElse(null);
+
+        Set<Object> existingPKs = (pkColumn != null)
+                ? fetchExistingPrimaryKeys(schema, metadata.getTableName(), pkColumn)
+                : Collections.emptySet();
+
+        int generated = 0;
+        while (generated < rowCount) {
+            Map<String, Object> row = new HashMap<>();
+
+            for (ColumnMetadata column : metadata.getColumns()) {
+                ColumnDataGenerator generator = DataGeneratorFactory.getGenerator(column.getDataType());
+                Object value = generator.generate();
+                row.put(column.getColumnName(), value);
+            }
+
+            if (pkColumn != null) {
+                Object pkValue = row.get(pkColumn);
+                if (existingPKs.contains(pkValue)) continue;
+                existingPKs.add(pkValue);
+            }
+
+            rows.add(row);
+            generated++;
+        }
+
+        return rows;
+
+}
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    public void insertRows(String schema, String tableName, List<Map<String, Object>> rows) {
+        if (rows.isEmpty()) return;
+
+        String columns = String.join(", ", rows.get(0).keySet());
+
+        String placeholders = String.join(", ", Collections.nCopies(rows.get(0).size(), "?"));
+
+        String sql = String.format("INSERT INTO %s.%s (%s) VALUES (%s)", schema, tableName, columns, placeholders);
+
+        for (Map<String, Object> row : rows) {
+            jdbcTemplate.update(sql, row.values().toArray());
+        }
+    }
+
+    public Set<Object> fetchExistingPrimaryKeys(String schema, String tableName, String primaryKeyColumn) {
+        String sql = String.format("SELECT %s FROM %s.%s", primaryKeyColumn, schema, tableName);
+        List<Object> existing = jdbcTemplate.queryForList(sql, Object.class);
+        return new HashSet<>(existing);
+    }
+
+
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/IntegerGenerator.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/IntegerGenerator.java
@@ -1,2 +1,10 @@
-package com.hisham.dummydatagenerator.generator;public class IntegerGenerator {
+package com.hisham.dummydatagenerator.generator;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class IntegerGenerator implements ColumnDataGenerator {
+    @Override
+    public Object generate() {
+        return ThreadLocalRandom.current().nextInt(1, 10000);
+    }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/IntegerGenerator.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/IntegerGenerator.java
@@ -5,6 +5,6 @@ import java.util.concurrent.ThreadLocalRandom;
 public class IntegerGenerator implements ColumnDataGenerator {
     @Override
     public Object generate() {
-        return ThreadLocalRandom.current().nextInt(1, 10000);
+        return ThreadLocalRandom.current().nextInt(1, 100000000);
     }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/generator/StringGenerator.java
+++ b/src/main/java/com/hisham/dummydatagenerator/generator/StringGenerator.java
@@ -1,2 +1,10 @@
-package com.hisham.dummydatagenerator.generator;public class StringGenerator {
+package com.hisham.dummydatagenerator.generator;
+
+import java.util.UUID;
+
+public class StringGenerator implements ColumnDataGenerator {
+    @Override
+    public Object generate() {
+        return "name_" + UUID.randomUUID().toString().substring(0, 8);
+    }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/schema/ColumnMetadata.java
+++ b/src/main/java/com/hisham/dummydatagenerator/schema/ColumnMetadata.java
@@ -4,11 +4,13 @@ public class ColumnMetadata {
     private String columnName;
     private String dataType;
     private boolean nullable;
+    private boolean primaryKey;
 
-    public ColumnMetadata(String columnName, String dataType, boolean nullable) {
+    public ColumnMetadata(String columnName, String dataType, boolean nullable, boolean primaryKey) {
         this.columnName = columnName;
         this.dataType = dataType;
         this.nullable = nullable;
+        this.primaryKey = primaryKey;
     }
 
     // Getters and setters
@@ -22,5 +24,9 @@ public class ColumnMetadata {
 
     public boolean isNullable() {
         return nullable;
+    }
+
+    public boolean isPrimaryKey() {
+        return primaryKey;
     }
 }

--- a/src/main/java/com/hisham/dummydatagenerator/schema/TableMetadata.java
+++ b/src/main/java/com/hisham/dummydatagenerator/schema/TableMetadata.java
@@ -19,4 +19,5 @@ public class TableMetadata {
     public List<ColumnMetadata> getColumns() {
         return columns;
     }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=DummyDataGenerator
 
 # Postgres properties
-spring.datasource.url=jdbc:postgresql://localhost:5432/ddg_init
-spring.datasource.username=postgres
-spring.datasource.password=postgres
+spring.datasource.url=${SPRING_DATASOURCE_URL}
+spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
+spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 # JPA properties
@@ -21,3 +21,6 @@ logging.level.org.hibernate.SQL=DEBUG
 
 # Application (DDG) properties
 dummy.generator.default.rowcount=1000
+
+# Make spring boot bind to localhost
+server.address=0.0.0.0


### PR DESCRIPTION
The current solution was two folds:

1. Increasing the range of randomness that we're creating values to avoid duplication.
2. Grabbing the values from the table and ensuring they won't get written into the table again. This can be inefficient if the table grows large.

Improvements:

1. Keeping track of the values that we create to make sure that we don't attempt to write the same value twice. 
2. Make (2) optional and only required if range of integers that is a key small.